### PR TITLE
Use a reference instead of manually specifying linking to ByePgLib.lib

### DIFF
--- a/ExHook/ExHook.vcxproj
+++ b/ExHook/ExHook.vcxproj
@@ -52,7 +52,7 @@
     </ClCompile>
     <Link>
       <EntryPointSymbol>DriverEntry</EntryPointSymbol>
-      <AdditionalDependencies>$(SolutionDir)Output\ByePgLib.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -63,6 +63,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="NT\Internals.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ByePgLib\ByePgLib.vcxproj">
+      <Project>{bf00f6e3-e234-4a7f-8ae5-89754f362d9f}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ExceptionHookingDemo/ExceptionHookingDemo.vcxproj
+++ b/ExceptionHookingDemo/ExceptionHookingDemo.vcxproj
@@ -52,7 +52,7 @@
     </ClCompile>
     <Link>
       <EntryPointSymbol>EntryPoint</EntryPointSymbol>
-      <AdditionalDependencies>$(SolutionDir)Output\ByePgLib.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -60,6 +60,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ByePgLib\ByePgLib.vcxproj">
+      <Project>{bf00f6e3-e234-4a7f-8ae5-89754f362d9f}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/FreeSeh/FreeSeh.vcxproj
+++ b/FreeSeh/FreeSeh.vcxproj
@@ -52,7 +52,7 @@
     </ClCompile>
     <Link>
       <EntryPointSymbol>EntryPoint</EntryPointSymbol>
-      <AdditionalDependencies>$(SolutionDir)Output\ByePgLib.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -63,6 +63,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="NT\SEH.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ByePgLib\ByePgLib.vcxproj">
+      <Project>{bf00f6e3-e234-4a7f-8ae5-89754f362d9f}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/InfinityHookFix/InfinityHookFix.vcxproj
+++ b/InfinityHookFix/InfinityHookFix.vcxproj
@@ -52,7 +52,7 @@
     </ClCompile>
     <Link>
       <EntryPointSymbol>EntryPoint</EntryPointSymbol>
-      <AdditionalDependencies>$(SolutionDir)Output\ByePgLib.lib;%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfLdr.lib;$(KMDF_LIB_PATH)$(KMDF_VER_PATH)\WdfDriverEntry.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -63,6 +63,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IhFix.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ByePgLib\ByePgLib.vcxproj">
+      <Project>{bf00f6e3-e234-4a7f-8ae5-89754f362d9f}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This fixes the issue of a full rebuild not working properly. If you would like to specify the lib manually for some reason it is also possible, but you would have to set the solution dependencies for each project manually. Project references automatically do this.